### PR TITLE
Add new APIs and fix bugs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_size = 2
+quote_type = double
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    },
+    "editor.formatOnSave": true
+  },
+  "prettier.trailingComma": "none"
+}

--- a/README.md
+++ b/README.md
@@ -14,14 +14,42 @@ This repository was based on [ant-plus the original module for Node.js](https://
 npm install web-ant-plus
 ```
 
-#### Create USB stick GarminStick2 or GarminStick3
+### Create USB stick
+
+There are several ways to create a USB stick that can be used to start/create a sensor:
+
+#### Create a specific USB stick GarminStick2 or GarminStick3
 
 ```typescript
 import { GarminStick3 } from "web-ant-plus";
 const stick = new GarminStick3();
 ```
 
-#### Create sensors
+#### Create USB stick from a new pairing
+
+This method will create a USBDriver (`stick`) from an ANT+ USB stick that has already been paired (i.e. will not open the dialog but rather filter for already paired usb devices). Please note that if more than one ANT+ stick was paired it will chose the first one.
+
+```typescript
+const stick = USBDriver.createFromPairedDevice();
+```
+
+#### Create USB stick from a specific USBDevice instance
+
+This method will create a USBDriver (`stick`) from a USBDevice instance. Please note that this does not do any checks whether USBDevice instance is in fact an ANT+ stick.
+
+```typescript
+const stick = USBDriver.createFromDevice();
+```
+
+#### Create USB stick from an already paired device
+
+This method will open a prompt to pair a usb device to connect to. Once connected it will return a USBDriver instance (`stick`)
+
+```typescript
+const stick = USBDriver.createFromNewDevice();
+```
+
+### Create sensors
 
 ```typescript
 const hrSensor = new HeartRateSensor(stick);
@@ -42,10 +70,10 @@ stick.on("startup", function () {
 #### Open stick
 
 ```typescript
-if (!stick.open()) {
-  console.log("Stick not found!");
-}
+await stick.open();
 ```
+
+Please note that the `open()` method will resolve the promise only once the stick is closed (or rejected due to an error). In this case it will return the underlying USBDevice instance. In practice this should mean that the `open()` method, if awaited, is blocking until the communication with stick terminates.
 
 ### scanning
 
@@ -95,7 +123,7 @@ which has a USB product ID of `0x1009`.
 
 - open()
 
-  - Tries to open the stick. Returns false on failure.
+  - Tries to open the stick. Returns a promise that resolves once the stick is closed (or the promise is rejected due to an error). In this case it will return the underlying USBDevice instance. In practice this should mean that the `open()` method if awaited is blocking until the communication with stick terminates.
 
 - close()
 
@@ -117,7 +145,7 @@ which has a USB product ID of `0x1009`.
 
 ### Common to all Sensors
 
-#### methods
+#### Sensors methods
 
 - attach(channel: number, deviceID: number)
 
@@ -127,7 +155,7 @@ which has a USB product ID of `0x1009`.
 
   - Detaches the sensor.
 
-#### events
+#### Sensors events
 
 - attached
 
@@ -139,7 +167,7 @@ which has a USB product ID of `0x1009`.
 
 ### Common to all Scanners
 
-#### methods
+#### Scanners methods
 
 - scan()
 
@@ -149,7 +177,7 @@ which has a USB product ID of `0x1009`.
 
   - Detaches the sensor.
 
-#### events
+#### Scanners events
 
 - attached
 
@@ -161,7 +189,7 @@ which has a USB product ID of `0x1009`.
 
 ### HeartRate
 
-#### events
+#### HeartRate events
 
 - hbData
 
@@ -169,13 +197,13 @@ which has a USB product ID of `0x1009`.
 
 ### SpeedCadence
 
-#### methods
+#### SpeedCadence methods
 
 #### setWheelCircumference(circumferenceInMeters)
 
 Calibrates the speed sensor. Defaults to a wheel with diameter of 70cm (= 2.199).
 
-#### events
+#### SpeedCadence events
 
 - speedData
 
@@ -187,7 +215,7 @@ Calibrates the speed sensor. Defaults to a wheel with diameter of 70cm (= 2.199)
 
 ### StrideSpeedDistance
 
-#### events
+#### StrideSpeedDistance events
 
 - ssdData
 
@@ -195,7 +223,7 @@ Calibrates the speed sensor. Defaults to a wheel with diameter of 70cm (= 2.199)
 
 ### BicyclePower
 
-#### events
+#### BicyclePower events
 
 - powerData
 
@@ -203,7 +231,7 @@ Calibrates the speed sensor. Defaults to a wheel with diameter of 70cm (= 2.199)
 
 ### FitnessEquipment
 
-#### events
+#### FitnessEquipment events
 
 - fitnessData
 
@@ -211,7 +239,7 @@ Calibrates the speed sensor. Defaults to a wheel with diameter of 70cm (= 2.199)
 
 ### Environment
 
-#### events
+#### Environment events
 
 - envData
 
@@ -219,7 +247,7 @@ Calibrates the speed sensor. Defaults to a wheel with diameter of 70cm (= 2.199)
   - The `state.EventCount` value can be used to tell when a new measurement has been made by the sensor -
     it's value will have been incremented.
 
-```
+```text
 This software is subject to the ANT+ Shared Source License www.thisisant.com/swlicenses
 Copyright (c) Garmin Canada Inc. 2018
 All rights reserved.

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": false,
@@ -16,6 +20,14 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src", "../src/**/*.ts"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": [
+    "src",
+    "../src/**/*.ts",
+    "../src/index.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1229,9 +1229,9 @@
       }
     },
     "node_modules/@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -1631,18 +1631,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2038,9 +2026,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
       "dev": true
     },
     "node_modules/damerau-levenshtein": {
@@ -2992,15 +2980,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -3069,13 +3048,19 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
       "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/globalthis": {
@@ -3153,15 +3138,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -3178,6 +3154,18 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -3559,18 +3547,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
       "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
-    },
-    "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4141,15 +4117,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/react-refresh": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
-      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -4516,18 +4483,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -4545,15 +4500,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -5663,9 +5609,9 @@
       }
     },
     "@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
       "dev": true
     },
     "@types/semver": {
@@ -5927,15 +5873,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
-    },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.0"
-      }
     },
     "argparse": {
       "version": "2.0.1",
@@ -6218,9 +6155,9 @@
       }
     },
     "csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
       "dev": true
     },
     "damerau-levenshtein": {
@@ -6947,12 +6884,6 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
-    "gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true
-    },
     "get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -7000,11 +6931,14 @@
         "is-glob": "^4.0.3"
       }
     },
-    "globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+    "globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
     },
     "globalthis": {
       "version": "1.0.3",
@@ -7058,12 +6992,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-      "dev": true
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
     },
     "has-property-descriptors": {
@@ -7335,12 +7263,6 @@
       "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
       "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
     },
-    "jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -7550,6 +7472,18 @@
         "es-errors": "^1.0.0"
       }
     },
+    "object.groupby": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.0.tgz",
+      "integrity": "sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.21.2",
+        "get-intrinsic": "^1.2.1"
+      }
+    },
     "object.hasown": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
@@ -7740,12 +7674,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "peer": true
-    },
-    "react-refresh": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
-      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
-      "dev": true
     },
     "regenerator-runtime": {
       "version": "0.13.11",
@@ -8002,15 +7930,6 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
-    "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
-    },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -8021,12 +7940,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
     },
     "to-regex-range": {

--- a/src/ICancellationToken.ts
+++ b/src/ICancellationToken.ts
@@ -1,3 +1,28 @@
 export interface ICancellationToken {
+  cancelled(): void;
   cancel(): void;
+}
+
+export class CancellationToken implements ICancellationToken {
+  get isCancelled(): boolean {
+    return this._isCancelled;
+  }
+  _isCancelled: boolean = false;
+  constructor() {}
+  cancelled() {
+    if (this._isCancelled) {
+      this._isCancelled = false;
+      throw new CancellationError();
+    }
+  }
+  cancel() {
+    this._isCancelled = true;
+  }
+}
+
+export class CancellationError extends Error {
+  constructor(message?: string) {
+    super(message ?? "Operation was cancelled");
+    this.name = "CancellationError";
+  }
 }

--- a/src/USBDriver.ts
+++ b/src/USBDriver.ts
@@ -41,6 +41,9 @@ export class USBDriver extends EventEmitter {
     this.setMaxListeners(50);
   }
 
+  /** Creates a USBDriver instance from an already paired (and permitted) device
+   * @Note If more than one ANT+ stick was paired the USBDriver instance will be created from the first one.
+   */
   public static async createFromPairedDevice(): Promise<USBDriver | undefined> {
     const device = (await this.getPairedDevices())?.[0];
 
@@ -54,6 +57,9 @@ export class USBDriver extends EventEmitter {
     return undefined;
   }
 
+  /** Starts the paring process by opening the dialog box, once USBDevice is connected it will return a USBDriver instance
+   * @Note This method filters the usb devices shown in the dialog box i.e. only ANT+ sticks will be shown.
+   */
   public static async createFromNewDevice(): Promise<USBDriver> {
     const device = await navigator.usb.requestDevice({
       filters: this.supportedDevices.map(
@@ -75,6 +81,9 @@ export class USBDriver extends EventEmitter {
     return driverInstance;
   }
 
+  /** Creates a USBDriver instance from the specified USBDevice
+   * @Note This method does not check if the provided USBDevice is in fact an ANT+ stick.
+   */
   public static createFromDevice(device: USBDevice): USBDriver {
     const driverInstance = new USBDriver(device.vendorId, device.productId);
     driverInstance.device = device;
@@ -82,6 +91,7 @@ export class USBDriver extends EventEmitter {
     return driverInstance;
   }
 
+  /** Gets an array of ANT+ usb sticks that has been previously paired and hence have permission to connect (if any) */
   public static async getPairedDevices(): Promise<Array<USBDevice>> {
     const devices = await navigator.usb.getDevices();
     return devices.filter(

--- a/src/USBDriver.ts
+++ b/src/USBDriver.ts
@@ -129,7 +129,7 @@ export class USBDriver extends EventEmitter {
     await this.reset();
     this.interface = undefined;
     if (!this.device) return;
-    this.device.close();
+    await this.device.close();
     this.emit("shutdown");
     const devIdx = this.deviceInUse.indexOf(this.device);
     if (devIdx >= 0) {
@@ -141,7 +141,6 @@ export class USBDriver extends EventEmitter {
 
   public async reset() {
     await this.detach_all();
-    await this.device?.reset();
     this.maxChannels = 0;
     this.usedChannels = 0;
     await this.write(Messages.resetSystem());

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { USBDriver } from "./USBDriver";
 export { Constants } from "./Constants";
 export { GarminStick2 } from "./GarminStick2";
 export { GarminStick3 } from "./GarminStick3";

--- a/src/sensors/SpeedCadenceSensorState.ts
+++ b/src/sensors/SpeedCadenceSensorState.ts
@@ -112,10 +112,10 @@ export class SpeedCadenceSensorState {
         cadenceDataChanged && speedDataChanged
           ? "both"
           : cadenceDataChanged
-            ? "cadence"
-            : speedDataChanged
-              ? "speed"
-              : "none"
+          ? "cadence"
+          : speedDataChanged
+          ? "speed"
+          : "none"
     };
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["./src/**/*.ts"],
+  "include": ["./src/**/*.ts", "src/index.ts"],
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,


### PR DESCRIPTION
This PR includes several improvements of the web ant plus library. It updates certain dependencies as well as include new APIs and several fixes. 

Most importantly it adds new static factory methods to create a USBDriver which essentially bypasses the need to specifically instantiate a GarminStick class instance before a USBDriver can be created. These new methods allow the creation of USBDriver from already paired devices (i.e. no need for selecting from the prompt) and start USBDriver from the USB device selected from the pairing prompt.

It also updates the documentation in the README to reflect the API and corrects some incorrect descriptions