### PR TITLE
Update project to use ES6 modules instead of CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ant-plus",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "description": "A package for ANT+ on Web browsers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["DOM", "ESNext"],
-    "module": "commonjs",
+    "module": "ES6",
     "moduleResolution": "node",
     "outDir": "./dist",
     "skipLibCheck": true,


### PR DESCRIPTION
In order to have better tree shakablitiy I propose changing the project to take advantage of ES6 modules instead of CommonJS. 

This would reduce the size of the final bundles as the unused sensors will not be included.

This is of course a breaking change as clients relying on the CommonJS require imports will need to migrate their projects. 

For this reason I bumped the version number to 2.0.0. 

However its almost 2025 and the ES6 proposal was accepted almost 10 years ago, and almost [96% of currently used browsers](https://caniuse.com/es6-module) support this syntax.